### PR TITLE
Add commercial licensing

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -1,0 +1,28 @@
+# Commercial Licensing
+
+The public **swatahVision** repository contains the **community core** licensed under the **GNU Lesser General Public License v3.0 (LGPL-3.0)**.
+
+In addition to the community core, **swatah.ai / NeuralSense AI Private Limited** offers separate commercial licensing for organizations that require production-grade deployment, enterprise integrations, or proprietary distribution rights.
+
+## Commercial offerings may include
+
+- advanced exception handling and runtime hardening
+- industrial and plant-system connectors
+- deployment orchestration and packaged distributions
+- observability, audit, and reporting layers
+- OEM / embedded / redistribution rights
+- customer-specific modules and extensions
+- enterprise support and maintenance
+
+## Scope clarification
+
+The LGPL-3.0 licensed repository remains the public community core.
+
+Enterprise modules, packaged deployments, customer-specific integrations, and commercial support offerings are licensed separately and are not included in this repository unless explicitly stated.
+
+## Contact
+
+For commercial licensing inquiries, contact:
+
+**swatah.ai (swatah.ai is a trading name for NeuralSense AI Pvt. Ltd)**  
+Email: **info@swatah.ai**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,5 +54,5 @@ When opening a pull request, please explain:
 
 For contribution-related questions or commercial discussions:
 
-**swatah.ai (swatah.ai is a trading name for NeuralSense AI Pvt. Ltd)**
-Email: info@swatah.ai
+**swatah.ai (swatah.ai is a trading name for NeuralSense AI Pvt. Ltd)**  
+Email: **info@swatah.ai**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing to swatahVision
+
+Thank you for your interest in contributing to **swatahVision**.
+
+The goal of this repository is to maintain a strong and reusable community core for Vision AI.
+
+## Before contributing
+
+By submitting a contribution, you confirm that:
+
+- you have the legal right to submit it
+- the contribution is your original work, or you have the necessary rights to contribute it
+- the contribution does not knowingly violate third-party intellectual property rights
+
+## Suitable contributions
+
+Examples of welcome contributions include:
+
+- bug fixes
+- tests
+- documentation improvements
+- performance improvements to community-core functionality
+- reusable framework-level enhancements
+- examples and developer tooling
+
+## Maintainer discretion
+
+The maintainers may decline contributions that are:
+
+- customer-specific
+- deployment-specific
+- tightly coupled to proprietary workflows
+- inconsistent with the direction of the community core
+
+## Licensing of contributions
+
+By submitting a contribution to this repository, you agree that:
+
+1. your contribution may be distributed as part of this project under **LGPL-3.0**.
+2. accepted contributions may also be used by the project owner in commercial and enterprise distributions of **swatahVision**.
+
+If you do not agree to these terms, do not submit a contribution.
+
+## Pull requests
+
+When opening a pull request, please explain:
+
+- what changed
+- why the change is useful
+- whether it introduces any breaking behavior
+- any relevant testing notes
+
+## Contact
+
+For contribution-related questions or commercial discussions:
+
+**swatah.ai (swatah.ai is a trading name for NeuralSense AI Pvt. Ltd)**
+Email: info@swatah.ai

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,9 @@
+Copyright © NeuralSense AI Private Limited.
+
+**swatah.ai** and **swatahVision** are trademarks, product names, or brand identifiers associated with NeuralSense AI Private Limited, unless otherwise stated.
+
+This repository is licensed under the GNU Lesser General Public License v3.0 (LGPL-3.0), unless a file or component explicitly states otherwise.
+
+Separate commercial editions, enterprise modules, customer-specific integrations, packaged deployments, and support offerings may exist outside this repository under separate commercial licensing terms.
+
+No trademark rights, branding rights, logo rights, or commercial identity rights are granted by the open-source license except where expressly permitted in writing.

--- a/README.md
+++ b/README.md
@@ -141,4 +141,22 @@ cv2.imwrite("out.jpg", annotated)
 ```
 ## License
 
-This work is licensed under LGPL 3.0
+**swatahVision** is licensed under the **GNU Lesser General Public License v3.0 (LGPL-3.0)**.
+
+This repository is the **community core** of **swatahVision** and is intended to provide an open, reusable Vision AI framework for model loading, inference, post-processing, tracking, visualization, and related utilities.
+
+### Commercial and Enterprise Use
+
+Separate commercial offerings are available from **swatah.ai / NeuralSense AI Private Limited** for organizations that require:
+
+- enterprise-grade deployment tooling
+- hardened runtime and advanced exception handling
+- industrial or plant-system integrations
+- packaged commercial distributions
+- OEM / embedded / redistribution rights
+- customer-specific extensions
+- commercial support and maintenance
+
+Open-source use of this repository remains governed by **LGPL-3.0**.
+
+Commercial modules, enterprise extensions, and customer-specific deployments are licensed separately and are **not part of this repository unless explicitly stated**.


### PR DESCRIPTION
docs(licensing): clarify LGPL community core and commercial enterprise structure

- add commercial licensing note for swatahVision
- define contributor terms for community and commercial reuse
- add ownership and trademark notice
- update README with community-core and enterprise licensing language
- keep public repo under LGPL-3.0 while separating commercial offerings