### PR TITLE
added asset downloader functionality

### DIFF
--- a/swatahvision/assets/downloader.py
+++ b/swatahvision/assets/downloader.py
@@ -1,0 +1,66 @@
+import os
+import requests
+
+from swatahvision.assets.list import ImageAssets, VideoAssets
+
+BASE_DIR = "assets"
+IMAGE_DIR = os.path.join(BASE_DIR, "images")
+VIDEO_DIR = os.path.join(BASE_DIR, "videos")
+
+os.makedirs(IMAGE_DIR, exist_ok=True)
+os.makedirs(VIDEO_DIR, exist_ok=True)
+
+
+def get_image(name):
+    asset = getattr(ImageAssets, name.upper(), None)
+    if not asset:
+        raise ValueError("Image not found")
+
+    return download_asset(asset, "image")
+
+
+def get_video(name):
+    asset = getattr(VideoAssets, name.upper(), None)
+    if not asset:
+        raise ValueError("Video not found")
+
+    return download_asset(asset, "video")
+
+    
+def download_asset(asset, asset_type="image"):
+    filename = asset["filename"]
+    url = asset["url"]
+
+    if asset_type == "image":
+        local_path = os.path.join(IMAGE_DIR, filename)
+    else:
+        local_path = os.path.join(VIDEO_DIR, filename)
+
+    # ✅ Already exists
+    if os.path.exists(local_path):
+        return local_path
+
+    print(f"Downloading {filename}...")
+    print("URL:",url)
+    response = requests.get(url,headers={"User-Agent":"Mozilla/5.0"})
+    print("Status Code:", response.status_code)
+    if response.status_code != 200:
+        print("Response Text:",response.status_code)
+        raise Exception("Download failed")
+
+    with open(local_path, "wb") as f:
+        f.write(response.content)
+
+    return local_path
+if __name__ == "__main__":
+    print("Downloading all assets...")
+
+    # Download all images
+    for name, asset in ImageAssets.__dict__.items():
+        if not name.startswith("__"):
+            download_asset(asset, "image")
+
+    # Download all videos
+    for name, asset in VideoAssets.__dict__.items():
+        if not name.startswith("__"):
+            download_asset(asset, "video")

--- a/swatahvision/assets/list.py
+++ b/swatahvision/assets/list.py
@@ -1,0 +1,77 @@
+class ImageAssets:
+    CAR = {
+        "filename": "car.jpg",
+        "url": "https://huggingface.co/datasets/swatah/swatahvision-assets/resolve/main/images/car.jpg"
+    }
+
+    DOG = {
+        "filename": "dog.jpg",
+        "url": "https://huggingface.co/datasets/swatah/swatahvision-assets/resolve/main/images/dog.jpg"
+    }
+
+    PEOPLE_WALKING = {
+        "filename": "people-walking.jpg",
+        "url": "https://huggingface.co/datasets/swatah/swatahvision-assets/resolve/main/images/people-walking.jpg"
+    }
+
+    SOCCER = {
+        "filename": "soccer.jpg",
+        "url": "https://huggingface.co/datasets/swatah/swatahvision-assets/resolve/main/images/soccer.jpg"
+    }
+
+
+class VideoAssets:
+    VEHICLES = {
+        "filename": "vehicles.mp4",
+        "url": "https://huggingface.co/swatah/swatahvision/resolve/main/videos/vehicles.mp4"
+    }
+
+    TRAFFIC = {
+        "filename": "traffic.mp4",
+        "url": "https://huggingface.co/swatah/swatahvision/resolve/main/videos/vehicles.mp4"
+    }
+
+    VEHICLES_2 = {
+        "filename": "vehicles-2.mp4",
+        "url": "https://huggingface.co/datasets/swatah/swatahvision-assets/resolve/main/videos/vehicles-2.mp4"
+    }
+
+    SUBWAY = {
+        "filename": "subway.mp4",
+        "url": "https://huggingface.co/datasets/swatah/swatahvision-assets/resolve/main/videos/subway.mp4"
+    }
+
+    SKIING = {
+        "filename": "skiing.mp4",
+        "url": "https://huggingface.co/datasets/swatah/swatahvision-assets/resolve/main/videos/skiing.mp4"
+    }
+
+    PEOPLE_WALKING = {
+        "filename": "people-walking.mp4",
+        "url": "https://huggingface.co/datasets/swatah/swatahvision-assets/resolve/main/videos/people-walking.mp4"
+    }
+
+    MILK_BOTTLING_PLANT = {
+        "filename": "milk-bottling-plant.mp4",
+        "url": "https://huggingface.co/datasets/swatah/swatahvision-assets/resolve/main/videos/milk-bottling-plant.mp4"
+    }
+
+    MARKET_SQUARE = {
+        "filename": "market-square.mp4",
+        "url": "https://huggingface.co/datasets/swatah/swatahvision-assets/resolve/main/videos/market-square.mp4"
+    }
+
+    GROCERY_STORE = {
+        "filename": "grocery-store.mp4",
+        "url": "https://huggingface.co/datasets/swatah/swatahvision-assets/resolve/main/videos/grocery-store.mp4"
+    }
+
+    BEACH = {
+        "filename": "beach-1.mp4",
+        "url": "https://huggingface.co/datasets/swatah/swatahvision-assets/resolve/main/videos/beach-1.mp4"
+    }
+
+    BASKETBALL = {
+        "filename": "basketball-1.mp4",
+        "url": "https://huggingface.co/datasets/swatah/swatahvision-assets/resolve/main/videos/basketball-1.mp4"
+    }


### PR DESCRIPTION
This PR introduces an asset downloader functionality for downloading images and videos from online sources.

Changes Made

- Added "list.py" to define image and video asset URLs
- Implemented downloader logic in "downloader.py"
- Ensured assets are downloaded into "assets/images" and "assets/videos" directories

How to Test

1. Run the following command:
   py -3.14 -m swatahvision.assets.downloader
2. Verify that:
   - Images are downloaded into "assets/images"
   - Videos are downloaded into "assets/videos"